### PR TITLE
The dedicated publish channel is now customizable.

### DIFF
--- a/src/Burrow/RabbitTunnel.cs
+++ b/src/Burrow/RabbitTunnel.cs
@@ -148,7 +148,7 @@ namespace Burrow
             }
         }
 
-        private void CreatePublishChannel()
+        protected virtual void CreatePublishChannel()
         {
             if (_dedicatedPublishingChannel == null || !_dedicatedPublishingChannel.IsOpen)
             {


### PR DESCRIPTION
In order to allow for publish confirmations, we need to be able to somehow customize the dedicated publish channel that is created by Burrow.Net.
