### PR TITLE
Missing Castle.Core dependency from Burrow.RPC NuGet package.

### DIFF
--- a/nuget/Burrow.RPC/Package.nuspec
+++ b/nuget/Burrow.RPC/Package.nuspec
@@ -16,7 +16,8 @@
     <copyright>Copyright 2012</copyright>
     <tags>Burrow Burrow.NET RabbitMQ RabbitMQ-client AMQP Burrow.RPC RPC</tags>
     <dependencies>		
-		<dependency id="Burrow.NET" version="1.0.16" />		
+		<dependency id="Burrow.NET" version="1.0.16" />
+        <dependency id="Castle.Core" version="3.1.0" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Hi,

The Burrow.RPC NuGet package doesn't have a dependency on Castle.Core, causing an error when added to a project. I've updated the nuspec package to include this.

Cheers, Rich
